### PR TITLE
Use insertOne over insert.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
-        mongodb-version: ['4.2']
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mongodb:
-        image: mongo:3.6
+        image: mongo:4.2
         ports:
           - 27017:27017
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mongodb:
-        image: mongo:3.6
+        image: mongo:4.2
         ports:
           - 27017:27017
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,8 @@ jobs:
           - 27017:27017
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
+        mongodb-version: ['4.2']
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # bedrock-ssm-mongodb ChangeLog
 
-## 2.1.0 -
+## 3.0.0 -
 
 ### Changed
-  - peerDependency for `bedrock-mongodb` is now 7.0.0
-  - Changed api calls from `insert` to `insertOne`
-  - Update test dependencies to `bedrock-mongodb: ^7.0.0`
+  - **BREAKING**: Upgrade to `bedrock-mongodb` ^7.0.0.
+  - Changed api calls from `insert` to `insertOne`.
+  - Update test dependencies to `bedrock-mongodb: ^7.0.0.
 
 ## 2.0.1 - 2020-01-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # bedrock-ssm-mongodb ChangeLog
 
+## 2.1.0 -
+
+### Changed
+  - peerDependency for `bedrock-mongodb` is now 7.0.0
+  - Changed api calls from `insert` to `insertOne`
+  - Update test dependencies to `bedrock-mongodb: ^7.0.0`
+
 ## 2.0.1 - 2020-01-22
 
 ### Fixed

--- a/lib/asymmetric-key.js
+++ b/lib/asymmetric-key.js
@@ -33,7 +33,7 @@ exports.generateKeyPair = async ({keyId, type}) => {
   };
 
   try {
-    await database.collections.ssm.insert(record, database.writeOptions);
+    await database.collections.ssm.insertOne(record, database.writeOptions);
   } catch(e) {
     if(!database.isDuplicateError(e)) {
       throw e;

--- a/lib/asymmetric-key.js
+++ b/lib/asymmetric-key.js
@@ -12,11 +12,11 @@ const {LDKeyPair} = require('crypto-ld');
  * Generates a new asymmetric key pair.
  *
  * @ignore
- * @param {Object} options - The options to use.
+ * @param {object} options - The options to use.
  * @param {string} options.keyId - The key ID to use.
- * @param {Object} options.type - The key type.
+ * @param {object} options.type - The key type.
  *
- * @returns {Promise<Object>} An object containing public key material.
+ * @returns {Promise<object>} An object containing public key material.
  */
 exports.generateKeyPair = async ({keyId, type}) => {
   const now = Date.now();
@@ -56,11 +56,11 @@ exports.generateKeyPair = async ({keyId, type}) => {
  * wisely.
  *
  * @ignore
- * @param {Object} options - The options to use.
- * @param {Object} options.key - The key to use.
- * @param {Object} options.operation - The KMS operation.
+ * @param {object} options - The options to use.
+ * @param {object} options.key - The key to use.
+ * @param {object} options.operation - The KMS operation.
  *
- * @returns {Promise<Object>} Contains `{signatureValue}`.
+ * @returns {Promise<object>} Contains `{signatureValue}`.
  */
 exports.sign = async ({key, operation}) => {
   const {verifyData} = operation;

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,11 +41,11 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
 /**
  * Generates a new key.
  *
- * @param {Object} options - The options to use.
+ * @param {object} options - The options to use.
  * @param {string} options.keyId - The key ID to use.
- * @param {Object} options.operation - The KMS operation.
+ * @param {object} options.operation - The KMS operation.
  *
- * @returns {Promise<Object>} Key information.
+ * @returns {Promise<object>} Key information.
  */
 exports.generateKey = async ({keyId, operation}) => {
   assert.string(keyId, 'options.keyId');
@@ -70,11 +70,11 @@ exports.generateKey = async ({keyId, operation}) => {
 /**
  * Wraps a cryptographic key using a key encryption key (KEK).
  *
- * @param {Object} options - The options to use.
+ * @param {object} options - The options to use.
  * @param {string} options.keyId - The key ID to use.
- * @param {Object} options.operation - The KMS operation.
+ * @param {object} options.operation - The KMS operation.
  *
- * @returns {Promise<Object>} An object containing `{wrappedKey}`.
+ * @returns {Promise<object>} An object containing `{wrappedKey}`.
  */
 exports.wrapKey = async ({keyId, operation}) => {
   assert.string(keyId, 'options.keyId');
@@ -100,11 +100,11 @@ exports.wrapKey = async ({keyId, operation}) => {
 /**
  * Unwraps a cryptographic key using a key encryption key (KEK).
  *
- * @param {Object} options - The options to use.
+ * @param {object} options - The options to use.
  * @param {string} options.keyId - The key ID to use.
- * @param {Object} options.operation - The KMS operation.
+ * @param {object} options.operation - The KMS operation.
  *
- * @returns {Promise<Object>} An object containing `{unwrappedKey}`.
+ * @returns {Promise<object>} An object containing `{unwrappedKey}`.
  */
 exports.unwrapKey = async ({keyId, operation}) => {
   assert.string(keyId, 'options.keyId');
@@ -133,11 +133,11 @@ exports.unwrapKey = async ({keyId, operation}) => {
  * hashing the data first may present interoperability issues so choose
  * wisely.
  *
- * @param {Object} options - The options to use.
+ * @param {object} options - The options to use.
  * @param {string} options.keyId - The key ID to use.
- * @param {Object} options.operation - The KMS operation.
+ * @param {object} options.operation - The KMS operation.
  *
- * @returns {Promise<Object>} An object containing `{signatureValue}`.
+ * @returns {Promise<object>} An object containing `{signatureValue}`.
  */
 exports.sign = async ({keyId, operation}) => {
   assert.string(keyId, 'options.keyId');
@@ -166,11 +166,11 @@ exports.sign = async ({keyId, operation}) => {
  * hashing the data first may present interoperability issues so choose
  * wisely.
  *
- * @param {Object} options - The options to use.
+ * @param {object} options - The options to use.
  * @param {string} options.keyId - The key ID to use.
- * @param {Object} options.operation - The KMS operation.
+ * @param {object} options.operation - The KMS operation.
  *
- * @returns {Promise<Object>} An object containing `{verified}`.
+ * @returns {Promise<object>} An object containing `{verified}`.
  */
 exports.verify = async ({keyId, operation}) => {
   assert.string(keyId, 'options.keyId');
@@ -199,11 +199,11 @@ exports.verify = async ({keyId, operation}) => {
 * a shared key itself, but rather input into a key derivation function (KDF)
 * to produce a shared key.
  *
- * @param {Object} options - The options to use.
+ * @param {object} options - The options to use.
  * @param {string} options.keyId - The key ID to use.
- * @param {Object} options.operation - The KMS operation.
+ * @param {object} options.operation - The KMS operation.
  *
- * @returns {Promise<Object>} An object containing `{secret}`.
+ * @returns {Promise<object>} An object containing `{secret}`.
  */
 exports.deriveSecret = async ({keyId, operation}) => {
   assert.string(keyId, 'options.keyId');
@@ -230,10 +230,10 @@ exports.deriveSecret = async ({keyId, operation}) => {
  * Gets a previously stored key record.
  *
  * @ignore
- * @param {Object} options - The options to use.
+ * @param {object} options - The options to use.
  * @param {string} options.id - The ID of the key.
  *
- * @returns {Promise<Object>} The key record.
+ * @returns {Promise<object>} The key record.
  */
 async function _getKeyRecord({id}) {
   assert.string(id, 'options.id');

--- a/lib/key-agreement-key.js
+++ b/lib/key-agreement-key.js
@@ -45,7 +45,7 @@ exports.generateKeyPair = async ({keyId, type}) => {
   };
 
   try {
-    await database.collections.ssm.insert(record, database.writeOptions);
+    await database.collections.ssm.insertOne(record, database.writeOptions);
   } catch(e) {
     if(!database.isDuplicateError(e)) {
       throw e;

--- a/lib/key-agreement-key.js
+++ b/lib/key-agreement-key.js
@@ -13,11 +13,11 @@ const nacl = require('tweetnacl');
  * Generates a new key agreement key pair.
  *
  * @ignore
- * @param {Object} options - The options to use.
+ * @param {object} options - The options to use.
  * @param {string} options.keyId - The key ID to use.
- * @param {Object} options.type - The key type.
+ * @param {object} options.type - The key type.
  *
- * @returns {Promise<Object>} An object containing public key material.
+ * @returns {Promise<object>} An object containing public key material.
  */
 exports.generateKeyPair = async ({keyId, type}) => {
   const now = Date.now();
@@ -70,11 +70,11 @@ exports.generateKeyPair = async ({keyId, type}) => {
  * wisely.
  *
  * @ignore
- * @param {Object} options - The options to use.
- * @param {Object} options.key - The key to use.
- * @param {Object} options.operation - The KMS operation.
+ * @param {object} options - The options to use.
+ * @param {object} options.key - The key to use.
+ * @param {object} options.operation - The KMS operation.
  *
- * @returns {Promise<Object>} Contains `{secret}`.
+ * @returns {Promise<object>} Contains `{secret}`.
  */
 exports.deriveSecret = async ({key, operation}) => {
   const {publicKey} = operation;

--- a/lib/symmetric-key.js
+++ b/lib/symmetric-key.js
@@ -39,7 +39,7 @@ exports.generateKey = async ({keyId, type}) => {
     key
   };
   try {
-    await database.collections.ssm.insert(record, database.writeOptions);
+    await database.collections.ssm.insertOne(record, database.writeOptions);
     return {'@context': _constants.SECURITY_CONTEXT_V2_URL, id: keyId, type};
   } catch(e) {
     if(!database.isDuplicateError(e)) {

--- a/lib/symmetric-key.js
+++ b/lib/symmetric-key.js
@@ -13,11 +13,10 @@ const {util: {BedrockError}} = require('bedrock');
  * Generates a new symmetric key.
  *
  * @ignore
- * @param {Object} options - The options to use.
+ * @param {object} options - The options to use.
  * @param {string} options.keyId - The key ID to use.
- * @param {Object} options.operation - The KMS operation.
- *
- * @returns {Promise<Object>} An object containing `{id}`.
+ * @param {string} options.type - A KEY_TYPE.
+ * @returns {Promise<object>} An object containing `{id}`.
  */
 exports.generateKey = async ({keyId, type}) => {
   if(!_constants.KEY_TYPES.symmetric.has(type)) {
@@ -61,11 +60,11 @@ exports.generateKey = async ({keyId, type}) => {
  * wisely.
  *
  * @ignore
- * @param {Object} options - The options to use.
- * @param {Object} options.key - The key to use.
- * @param {Object} options.operation - The KMS operation.
+ * @param {object} options - The options to use.
+ * @param {object} options.key - The key to use.
+ * @param {object} options.operation - The KMS operation.
  *
- * @returns {Promise<Object>} Contains `{signatureValue}`.
+ * @returns {Promise<object>} Contains `{signatureValue}`.
  */
 exports.sign = async ({key, operation}) => {
   if(key.type !== 'Sha256HmacKey2019') {
@@ -83,11 +82,11 @@ exports.sign = async ({key, operation}) => {
  * wisely.
  *
  * @ignore
- * @param {Object} options - The options to use.
- * @param {Object} options.key - The key to use.
- * @param {Object} options.operation - The KMS operation.
+ * @param {object} options - The options to use.
+ * @param {object} options.key - The key to use.
+ * @param {object} options.operation - The KMS operation.
  *
- * @returns {Promise<Object>} An object containing `{verified}`.
+ * @returns {Promise<object>} An object containing `{verified}`.
  */
 exports.verify = async ({key, operation}) => {
   if(key.type !== 'Sha256HmacKey2019') {
@@ -102,11 +101,11 @@ exports.verify = async ({key, operation}) => {
  * Wraps a cryptographic key using a key encryption key (KEK).
  *
  * @ignore
- * @param {Object} options - The options to use.
+ * @param {object} options - The options to use.
  * @param {string} options.kek - The key encryption key to use.
- * @param {Object} options.operation - The KMS operation.
+ * @param {object} options.operation - The KMS operation.
  *
- * @returns {Promise<Object>} An object containing `{wrappedKey}`.
+ * @returns {Promise<object>} An object containing `{wrappedKey}`.
  */
 exports.wrapKey = async ({kek, operation}) => {
   if(kek.type !== 'AesKeyWrappingKey2019') {
@@ -121,11 +120,11 @@ exports.wrapKey = async ({kek, operation}) => {
  * Unwraps a cryptographic key using a key encryption key (KEK).
  *
  * @ignore
- * @param {Object} options - The options to use.
+ * @param {object} options - The options to use.
  * @param {string} options.kek - The key encryption key to use.
- * @param {Object} options.operation - The KMS operation.
+ * @param {object} options.operation - The KMS operation.
  *
- * @returns {Promise<Object>} An object containing `{unwrappedKey}`.
+ * @returns {Promise<object>} An object containing `{unwrappedKey}`.
  */
 exports.unwrapKey = async ({kek, operation}) => {
   if(kek.type !== 'AesKeyWrappingKey2019') {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "bedrock": "1.15.0 - 3.x",
-    "bedrock-mongodb": "5.5.0 - 6.x",
+    "bedrock-mongodb": "^7.0.0",
     "bedrock-package-manager": "^1.0.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "bedrock-package-manager": "^1.0.0"
   },
   "engines": {
-    "node": ">=8.9.0"
+    "node": ">=10.0.0"
   },
   "devDependencies": {
-    "eslint": "^6.6.0",
+    "eslint": "^7.2.0",
     "eslint-config-digitalbazaar": "^2.0.1",
-    "eslint-plugin-jsdoc": "^4.4.0",
+    "eslint-plugin-jsdoc": "^27.0.4",
     "jsdoc": "^3.5.5",
     "jsdoc-to-markdown": "^4.0.1"
   }

--- a/test/package.json
+++ b/test/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "base64url-universal": "^1.0.0",
     "bedrock": "^3.0.0",
-    "bedrock-mongodb": "^6.0.0",
+    "bedrock-mongodb": "digitalbazaar/bedrock-mongodb#driver3",
     "bedrock-package-manager": "^1.0.0",
     "bedrock-ssm-mongodb": "file:..",
     "bedrock-test": "^5.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "base64url-universal": "^1.0.0",
     "bedrock": "^3.0.0",
-    "bedrock-mongodb": "digitalbazaar/bedrock-mongodb#driver3",
+    "bedrock-mongodb": "^7.0.0",
     "bedrock-package-manager": "^1.0.0",
     "bedrock-ssm-mongodb": "file:..",
     "bedrock-test": "^5.0.0",


### PR DESCRIPTION
This should be good to go with the latest mongo driver.
This package does not depend on any other mongo dependent packages.

These PRs will be ready once version 3.0.0 of this package is released:

https://github.com/digitalbazaar/bedrock-kms/pull/23

This PR should come first with the following PR after it:

https://github.com/digitalbazaar/bedrock-permission/pull/22
https://github.com/digitalbazaar/bedrock-identity/pull/34