### PR TITLE
Add `maxAge` for cached key records.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # bedrock-ssm-mongodb ChangeLog
 
+## 3.2.1 - 2020-09-xx
+
+### Fixed
+- Add and apply max age for cache for key records. Without
+  this fix the cache can hold key records indefinitely even
+  when they are changed by other processes.
+
 ## 3.2.0 - 2020-09-22
 
 ### Added

--- a/lib/config.js
+++ b/lib/config.js
@@ -7,5 +7,6 @@ const {config} = require('bedrock');
 
 const cfg = config['ssm-mongodb'] = {};
 cfg.keyRecordCache = {
-  maxSize: 100
+  maxSize: 100,
+  maxAge: 5000
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -250,8 +250,9 @@ async function _getKeyRecord({id}) {
     return promise;
   }
 
-  promise = _getUnCachedKeyRecord({id});
-  KEY_RECORD_CACHE.set(id, promise);
+  promise = _getUncachedKeyRecord({id});
+  KEY_RECORD_CACHE.set(
+    id, promise, bedrock.config['ssm-mongodb'].keyRecordCache.maxAge);
 
   let record;
   try {
@@ -264,7 +265,7 @@ async function _getKeyRecord({id}) {
   return record;
 }
 
-async function _getUnCachedKeyRecord({id}) {
+async function _getUncachedKeyRecord({id}) {
   assert.string(id, 'options.id');
 
   const record = await database.collections.ssm.findOne(

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2019 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2019-2020 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
@@ -22,7 +22,10 @@ require('./config');
 
 bedrock.events.on('bedrock.init', async () => {
   const cfg = bedrock.config['ssm-mongodb'];
-  KEY_RECORD_CACHE = new LRU({max: cfg.keyRecordCache.maxSize});
+  KEY_RECORD_CACHE = new LRU({
+    max: cfg.keyRecordCache.maxSize,
+    maxAge: cfg.keyRecordCache.maxAge
+  });
   return brPackageManager.register({
     alias: 'ssm-v1',
     packageName: 'bedrock-ssm-mongodb',
@@ -251,8 +254,7 @@ async function _getKeyRecord({id}) {
   }
 
   promise = _getUncachedKeyRecord({id});
-  KEY_RECORD_CACHE.set(
-    id, promise, bedrock.config['ssm-mongodb'].keyRecordCache.maxAge);
+  KEY_RECORD_CACHE.set(id, promise);
 
   let record;
   try {


### PR DESCRIPTION
I consider this is a fix because the current cache implementation is flawed. Without an max age on cached key records, changes made to key records via other processes may never be reflected.